### PR TITLE
Added hashCode method to DsDef class

### DIFF
--- a/src/main/java/org/rrd4j/core/DsDef.java
+++ b/src/main/java/org/rrd4j/core/DsDef.java
@@ -146,6 +146,11 @@ public class DsDef {
         return false;
     }
 
+    @Override
+    public int hashCode() {
+        return dsName.hashCode();
+    }
+
     boolean exactlyEqual(DsDef def) {
         return dsName.equals(def.dsName) && dsType == def.dsType &&
                 heartbeat == def.heartbeat && Util.equal(minValue, def.minValue) &&


### PR DESCRIPTION
hashCode() method was missing in DsDef, this can cause issues with Set<> for example.