### PR TITLE
Fix imageio*.tmp not cleaned up in temporary dir when graphing

### DIFF
--- a/src/main/java/org/rrd4j/graph/ImageWorker.java
+++ b/src/main/java/org/rrd4j/graph/ImageWorker.java
@@ -218,13 +218,17 @@ class ImageWorker {
 
         try {
             writer.write(null, new IIOImage(outputImage, null, null), iwp);
+            imageStream.flush();
         } catch (IOException e) {
             writer.abort();
             throw e;
+        } finally {
+            try {
+                imageStream.close();
+            } catch (Exception inner) {
+            }
+            writer.dispose();
         }
-        writer.dispose();
-
-        imageStream.flush();
     }
 
     byte[] saveImage(String path, String type, float quality, boolean interlaced) throws IOException {


### PR DESCRIPTION
imageio*.tmp files are used by ImageIO ImageWriter for caching. The file should be release on ImageWriter.dispose() but in this case will not because OutputStream is not closed. (see http://info.michael-simons.eu/2012/01/25/the-dangers-of-javas-imageio/).
Note that these files are not cleaned-up on JVM shut-down, so they indefinitely stay on MS machines, and will be eventually deleted after a reboot on Unix.
The following patch fix the problem for me on Linux.