### PR TITLE
squid:S1132 - Strings literals should be placed on the left side when checking for equality

### DIFF
--- a/src/main/java/org/rrd4j/core/RrdDef.java
+++ b/src/main/java/org/rrd4j/core/RrdDef.java
@@ -275,7 +275,7 @@ public class RrdDef {
         for (int curTok = 0; tokenizer.hasMoreTokens(); curTok++) {
             tokens[curTok] = tokenizer.nextToken();
         }
-        if (!tokens[0].equalsIgnoreCase("DS")) {
+        if (!"DS".equalsIgnoreCase(tokens[0])) {
             throw illArgException;
         }
         String dsName = tokens[1];
@@ -288,7 +288,7 @@ public class RrdDef {
             throw illArgException;
         }
         double minValue = Double.NaN;
-        if (!tokens[4].equalsIgnoreCase("U")) {
+        if (!"U".equalsIgnoreCase(tokens[4])) {
             try {
                 minValue = Double.parseDouble(tokens[4]);
             }
@@ -297,7 +297,7 @@ public class RrdDef {
             }
         }
         double maxValue = Double.NaN;
-        if (!tokens[5].equalsIgnoreCase("U")) {
+        if (!"U".equalsIgnoreCase(tokens[5])) {
             try {
                 maxValue = Double.parseDouble(tokens[5]);
             }
@@ -391,7 +391,7 @@ public class RrdDef {
         for (int curTok = 0; tokenizer.hasMoreTokens(); curTok++) {
             tokens[curTok] = tokenizer.nextToken();
         }
-        if (!tokens[0].equalsIgnoreCase("RRA")) {
+        if (!"RRA".equalsIgnoreCase(tokens[0])) {
             throw illArgException;
         }
         ConsolFun consolFun = ConsolFun.valueOf(tokens[1]);

--- a/src/main/java/org/rrd4j/core/RrdDefTemplate.java
+++ b/src/main/java/org/rrd4j/core/RrdDefTemplate.java
@@ -160,7 +160,7 @@ public class RrdDefTemplate extends XmlTemplate {
      *                                  method call
      */
     public RrdDef getRrdDef() {
-        if (!root.getTagName().equals("rrd_def")) {
+        if (!"rrd_def".equals(root.getTagName())) {
             throw new IllegalArgumentException("XML definition must start with <rrd_def>");
         }
         validateTagsOnlyOnce(root, new String[]{

--- a/src/main/java/org/rrd4j/core/Sample.java
+++ b/src/main/java/org/rrd4j/core/Sample.java
@@ -166,7 +166,7 @@ public class Sample {
             time = Long.parseLong(timeToken);
         }
         catch (NumberFormatException nfe) {
-            if (timeToken.equalsIgnoreCase("N") || timeToken.equalsIgnoreCase("NOW")) {
+            if ("N".equalsIgnoreCase(timeToken) || "NOW".equalsIgnoreCase(timeToken)) {
                 time = Util.getTime();
             }
             else {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1132 - Strings literals should be placed on the left side when checking for equality.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1132
Please let me know if you have any questions.
George Kankava