### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/org/rrd4j/core/RrdDbPool.java
+++ b/src/main/java/org/rrd4j/core/RrdDbPool.java
@@ -20,6 +20,8 @@ import java.util.concurrent.locks.ReentrantLock;
 public class RrdDbPool {
     private static class RrdDbPoolSingletonHolder {
         static final RrdDbPool instance = new RrdDbPool();
+
+        private RrdDbPoolSingletonHolder() {}
     }
 
     /**

--- a/src/main/java/org/rrd4j/core/RrdNioBackendFactory.java
+++ b/src/main/java/org/rrd4j/core/RrdNioBackendFactory.java
@@ -142,5 +142,7 @@ public class RrdNioBackendFactory extends RrdFileBackendFactory {
          * The default thread pool used to periodically sync the mapped file to disk with.
          */
         static RrdSyncThreadPool INSTANCE = new RrdSyncThreadPool(syncPoolSize);
+
+        private DefaultSyncThreadPool() {}
     }
 }

--- a/src/main/java/org/rrd4j/demo/Demo.java
+++ b/src/main/java/org/rrd4j/demo/Demo.java
@@ -40,6 +40,8 @@ public class Demo {
     static final int IMG_WIDTH = 500;
     static final int IMG_HEIGHT = 300;
 
+    private Demo() {}
+
     /**
      * <p>To start the demo, use the following command:</p>
      * <pre>

--- a/src/main/java/org/rrd4j/graph/RrdGraphConstants.java
+++ b/src/main/java/org/rrd4j/graph/RrdGraphConstants.java
@@ -258,6 +258,8 @@ public interface RrdGraphConstants {
      * Font constructor, to use embedded fonts
      */
     static class FontConstructor {
+        private FontConstructor() {}
+
         /**
          * Return the default RRD4J's default font for the given strength
          * @param type {@link java.awt.Font#BOLD} for a bold fond, any other value return plain style.

--- a/src/main/java/org/rrd4j/inspector/Util.java
+++ b/src/main/java/org/rrd4j/inspector/Util.java
@@ -5,6 +5,8 @@ import java.awt.*;
 import java.util.Vector;
 
 class Util {
+    private Util() {}
+
     static void centerOnScreen(Window window) {
         Toolkit t = Toolkit.getDefaultToolkit();
         Dimension screenSize = t.getScreenSize();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava