### PR TITLE
squid:MissingDeprecatedCheck - Deprecated elements should have both the annotation and the Javadoc tag

### DIFF
--- a/src/main/java/org/rrd4j/core/FetchData.java
+++ b/src/main/java/org/rrd4j/core/FetchData.java
@@ -295,6 +295,7 @@ public class FetchData {
      *                  (these string constants are conveniently defined in the {@link org.rrd4j.ConsolFun} class)
      * @throws java.lang.IllegalArgumentException Thrown if the given datasource name cannot be found in fetched data.
      * @return a double.
+     * @deprecated This method is deprecated.
      */
     @Deprecated
     public double getAggregate(String dsName, ConsolFun consolFun) {
@@ -313,6 +314,7 @@ public class FetchData {
      * @param consolFun     Consolidation function (MIN, MAX, LAST, FIRST, AVERAGE or TOTAL)
      * @return Aggregated value
      * @throws java.lang.IllegalArgumentException Thrown if invalid RPN expression is supplied
+     * @deprecated This method is deprecated
      */
     @Deprecated
     public double getRpnAggregate(String rpnExpression, ConsolFun consolFun) {
@@ -327,6 +329,7 @@ public class FetchData {
      * @param dsName Datasource name.
      * @return Simple object containing all aggregated values.
      * @throws java.lang.IllegalArgumentException Thrown if the given datasource name cannot be found in the fetched data.
+     * @deprecated This method is deprecated.
      */
     @Deprecated
     public Aggregates getAggregates(String dsName) {
@@ -346,6 +349,7 @@ public class FetchData {
      * @return Object containing all aggregated values
      * @throws java.lang.IllegalArgumentException Thrown if invalid RPN expression is supplied
      * @throws java.io.IOException if any.
+     * @deprecated This method is deprecated.
      */
     @Deprecated
     public Aggregates getRpnAggregates(String rpnExpression) throws IOException {
@@ -369,6 +373,7 @@ public class FetchData {
      * @param dsName Datasource name
      * @return 95th percentile of fetched source values
      * @throws java.lang.IllegalArgumentException Thrown if invalid source name is supplied
+     * @deprecated This method is deprecated
      */
     @Deprecated
     public double get95Percentile(String dsName) {
@@ -383,6 +388,7 @@ public class FetchData {
      * @param rpnExpression RRDTool-like RPN expression
      * @return 95-percentile
      * @throws java.lang.IllegalArgumentException Thrown if invalid RPN expression is supplied
+     * @deprecated This method is deprecated
      */
     @Deprecated
     public double getRpn95Percentile(String rpnExpression) {

--- a/src/main/java/org/rrd4j/data/DataProcessor.java
+++ b/src/main/java/org/rrd4j/data/DataProcessor.java
@@ -270,6 +270,7 @@ public class DataProcessor {
      *                                  or if datasource values are not yet calculated (method {@link #processData()}
      *                                  was not called)
      * @return a aggregate value as a double calculated from the source.
+     * @deprecated This method is deprecated.
      */
     @Deprecated
     public double getAggregate(String sourceName, ConsolFun consolFun) {
@@ -287,6 +288,7 @@ public class DataProcessor {
      * @throws java.lang.IllegalArgumentException Thrown if invalid datasource name is specified,
      *                                  or if datasource values are not yet calculated (method {@link #processData()}
      *                                  was not called)
+     * @deprecated This method is deprecated
      */
     @Deprecated
     public Aggregates getAggregates(String sourceName) {
@@ -325,6 +327,7 @@ public class DataProcessor {
      *
      * @param sourceName Datasource name
      * @return 95th percentile of fetched source values
+     * @deprecated This method is deprecated
      */
     @Deprecated
     public double get95Percentile(String sourceName) {
@@ -344,6 +347,7 @@ public class DataProcessor {
      *
      * @param sourceName Datasource name
      * @return 95th percentile of fetched source values
+     * @deprecated This method is deprecated
      */
     @Deprecated
     public double getPercentile(String sourceName) {
@@ -358,6 +362,7 @@ public class DataProcessor {
      * @param percentile Boundary percentile. Value of 95 (%) is suitable in most cases, but you are free
      *                   to provide your own percentile boundary between zero and 100.
      * @return Requested percentile of fetched source values
+     * @deprecated This method is deprecated
      */
     @Deprecated
     public double getPercentile(String sourceName, double percentile) {
@@ -457,6 +462,7 @@ public class DataProcessor {
      * @param name      source name.
      * @param defName   Name of the datasource to calculate the value from.
      * @param consolFun Consolidation function to use for value calculation
+     * @deprecated This method is deprecated.
      */
     @Deprecated
     public void addDatasource(String name, String defName, ConsolFun consolFun) {
@@ -475,6 +481,7 @@ public class DataProcessor {
      * @param sourceName - the datasource from which to extract the percentile.  Must be a previously
      *                     defined virtual datasource
      * @param percentile - the percentile to extract from the source datasource
+     * @deprecated This method is deprecated.
      */
     @Deprecated
     public void addDatasource(String name, String sourceName, double percentile) {

--- a/src/main/java/org/rrd4j/data/Source.java
+++ b/src/main/java/org/rrd4j/data/Source.java
@@ -30,12 +30,25 @@ abstract class Source {
         return timestamps;
     }
 
+    /**
+     * @param tStart
+     * @param tEnd
+     * @return
+     * @deprecated This method is deprecated.
+     */
     @Deprecated
     Aggregates getAggregates(long tStart, long tEnd) {
         Aggregator agg = new Aggregator(timestamps, values);
         return agg.getAggregates(tStart, tEnd);
     }
 
+    /**
+     * @param tStart
+     * @param tEnd
+     * @param percentile
+     * @return
+     * @deprecated This method is deprecated.
+     */
     @Deprecated
     double getPercentile(long tStart, long tEnd, double percentile) {
         Variable vpercent = new Variable.PERCENTILE((float) percentile);

--- a/src/main/java/org/rrd4j/graph/RrdGraphDef.java
+++ b/src/main/java/org/rrd4j/graph/RrdGraphDef.java
@@ -666,6 +666,7 @@ public class RrdGraphDef implements RrdGraphConstants {
      * font is selected.
      *
      * @param smallFont Default font for graphing. Use only monospaced fonts.
+     * @deprecated This method is deprecated.
      */
     @Deprecated
     public void setSmallFont(final Font smallFont) {
@@ -676,6 +677,7 @@ public class RrdGraphDef implements RrdGraphConstants {
      * Sets title font.
      *
      * @param largeFont Font to be used for graph title.
+     * @deprecated This method is deprecated.
      */
     @Deprecated
     public void setLargeFont(final Font largeFont) {
@@ -828,6 +830,7 @@ public class RrdGraphDef implements RrdGraphConstants {
      * @param name      Source name
      * @param defName   Other source name
      * @param consolFun Consolidation function to be applied to other datasource.
+     * @deprecated This method is deprecated.
      */
     @Deprecated
     public void datasource(String name, String defName, ConsolFun consolFun) {
@@ -878,6 +881,7 @@ public class RrdGraphDef implements RrdGraphConstants {
      *
      * @param name    Source name.
      * @param defName Other source name.
+     * @deprecated This method is deprecated.
      */
     @Deprecated
     public void percentile(String name, String defName) {
@@ -889,7 +893,8 @@ public class RrdGraphDef implements RrdGraphConstants {
      *
      * @param name    Source name.
      * @param defName Other source name.
-     * @param percent The percent value
+     * @param percent The percent value.
+     * @deprecated This method is deprecated.
      */
     @Deprecated
     public void percentile(String name, String defName, double percent) {
@@ -922,6 +927,7 @@ public class RrdGraphDef implements RrdGraphConstants {
      * @param srcName   Virtual source name
      * @param consolFun Consolidation function to be applied to the source
      * @param format    Format string (like "average = %10.3f %s")
+     * @deprecated This method is deprecated.
      */
     @Deprecated
     public void print(String srcName, ConsolFun consolFun, String format) {
@@ -996,9 +1002,10 @@ public class RrdGraphDef implements RrdGraphConstants {
      * This method does basically the same thing as {@link #print(String, ConsolFun, String)},
      * but the result is printed on the graph itself, below the chart area.
      *
-     * @param srcName   Virtual source name
-     * @param consolFun Consolidation function to be applied to the source
+     * @param srcName   Virtual source name.
+     * @param consolFun Consolidation function to be applied to the source.
      * @param format    Format string (like "average = %10.3f %s")
+     * @deprecated This method is deprecated.
      */
     @Deprecated
     public void gprint(String srcName, ConsolFun consolFun, String format) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:MissingDeprecatedCheck - Deprecated elements should have both the annotation and the Javadoc tag.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:MissingDeprecatedCheck 
Please let me know if you have any questions.
George Kankava