### PR TITLE
squid:S2131 - Primitives should not be boxed just for 'String' conversion

### DIFF
--- a/src/main/java/org/rrd4j/core/FetchData.java
+++ b/src/main/java/org/rrd4j/core/FetchData.java
@@ -264,7 +264,7 @@ public class FetchData {
         }
         buff.append("\n \n");
         for (int i = 0; i < timestamps.length; i++) {
-            buff.append(padWithBlanks("" + timestamps[i], 10));
+            buff.append(padWithBlanks(Long.toString(timestamps[i]), 10));
             buff.append(":");
             for (int j = 0; j < dsNames.length; j++) {
                 double value = values[j][i];

--- a/src/main/java/org/rrd4j/core/Util.java
+++ b/src/main/java/org/rrd4j/core/Util.java
@@ -147,11 +147,11 @@ public class Util {
         if (forceExponents) {
             return df.format(x);
         }
-        return "" + x;
+        return Double.toString(x);
     }
 
     static String formatDouble(double x, boolean forceExponents) {
-        return formatDouble(x, "" + Double.NaN, forceExponents);
+        return formatDouble(x, Double.toString(Double.NaN), forceExponents);
     }
 
     /**

--- a/src/main/java/org/rrd4j/core/XmlTemplate.java
+++ b/src/main/java/org/rrd4j/core/XmlTemplate.java
@@ -169,7 +169,7 @@ public abstract class XmlTemplate {
      * @param value value to be set in the XML template
      */
     public void setVariable(String name, boolean value) {
-        valueMap.put(name, "" + value);
+        valueMap.put(name, Boolean.toString(value));
     }
 
     /**

--- a/src/main/java/org/rrd4j/core/XmlWriter.java
+++ b/src/main/java/org/rrd4j/core/XmlWriter.java
@@ -78,7 +78,7 @@ public class XmlWriter {
      * @param value value to be placed between <code>&lt;tag&gt;</code> and <code>&lt;/tag&gt;</code>
      */
     public void writeTag(String tag, int value) {
-        writeTag(tag, "" + value);
+        writeTag(tag, Integer.toString(value));
     }
 
     /**
@@ -88,7 +88,7 @@ public class XmlWriter {
      * @param value value to be placed between <code>&lt;tag&gt;</code> and <code>&lt;/tag&gt;</code>
      */
     public void writeTag(String tag, long value) {
-        writeTag(tag, "" + value);
+        writeTag(tag, Long.toString(value));
     }
 
     /**
@@ -119,7 +119,7 @@ public class XmlWriter {
      * @param value value to be placed between <code>&lt;tag&gt;</code> and <code>&lt;/tag&gt;</code>
      */
     public void writeTag(String tag, boolean value) {
-        writeTag(tag, "" + value);
+        writeTag(tag, Boolean.toString(value));
     }
 
     /**

--- a/src/main/java/org/rrd4j/core/timespec/Epoch.java
+++ b/src/main/java/org/rrd4j/core/timespec/Epoch.java
@@ -127,7 +127,7 @@ public class Epoch extends JFrame {
             catch (NumberFormatException nfe) {
                 // failed, try as a date
                 try {
-                    inputField.setText("" + parseDate(time));
+                    inputField.setText(Long.toString(parseDate(time)));
                 }
                 catch (Exception e) {
                     inputField.setText("Could not convert, sorry");

--- a/src/main/java/org/rrd4j/data/DataProcessor.java
+++ b/src/main/java/org/rrd4j/data/DataProcessor.java
@@ -686,7 +686,7 @@ public class DataProcessor {
         }
         buffer.append("\n");
         for (int i = 0; i < timestamps.length; i++) {
-            buffer.append(format("" + timestamps[i], 12));
+            buffer.append(format(Long.toString(timestamps[i]), 12));
             for (int j = 0; j < names.length; j++) {
                 buffer.append(format(Util.formatDouble(values[j][i]), 20));
             }

--- a/src/main/java/org/rrd4j/graph/ValueAxisMrtg.java
+++ b/src/main/java/org/rrd4j/graph/ValueAxisMrtg.java
@@ -39,7 +39,7 @@ class ValueAxisMrtg implements RrdGraphConstants {
             labfmt += " ";
         }
         if (im.symbol != ' ') {
-            labfmt += im.symbol;
+            labfmt += Character.toString(im.symbol);
         }
         if (im.unit != null) {
             labfmt += im.unit;

--- a/src/main/java/org/rrd4j/inspector/ArchiveTableModel.java
+++ b/src/main/java/org/rrd4j/inspector/ArchiveTableModel.java
@@ -75,13 +75,13 @@ class ArchiveTableModel extends AbstractTableModel {
                         ArcState state = arc.getArcState(dsIndex);
                         values = new Object[]{
                                 arc.getConsolFun(),
-                                "" + arc.getXff(),
-                                "" + arc.getSteps(),
-                                "" + arc.getRows(),
+                                Double.toString(arc.getXff()),
+                                Integer.toString(arc.getSteps()),
+                                Integer.toString(arc.getRows()),
                                 InspectorModel.formatDouble(state.getAccumValue()),
-                                "" + state.getNanSteps(),
-                                "" + arc.getStartTime() + " [" + new Date(arc.getStartTime() * 1000L) + "]",
-                                "" + arc.getEndTime() + " [" + new Date(arc.getEndTime() * 1000L) + "]"
+                                Long.toString(state.getNanSteps()),
+                                Long.toString(arc.getStartTime()) + " [" + new Date(arc.getStartTime() * 1000L) + "]",
+                                Long.toString(arc.getEndTime()) + " [" + new Date(arc.getEndTime() * 1000L) + "]"
                         };
                     }
                     finally {

--- a/src/main/java/org/rrd4j/inspector/DataTableModel.java
+++ b/src/main/java/org/rrd4j/inspector/DataTableModel.java
@@ -109,7 +109,7 @@ class DataTableModel extends AbstractTableModel {
                             String date = new Date(timestamp * 1000L).toString();
                             String value = InspectorModel.formatDouble(robinValues[i]);
                             values[i] = new Object[]{
-                                    "" + timestamp, date, value
+                                    Long.toString(timestamp), date, value
                             };
                         }
                     }

--- a/src/main/java/org/rrd4j/inspector/DatasourceTableModel.java
+++ b/src/main/java/org/rrd4j/inspector/DatasourceTableModel.java
@@ -80,12 +80,12 @@ class DatasourceTableModel extends AbstractTableModel {
                         values = new Object[]{
                                 ds.getName(),
                                 ds.getType(),
-                                "" + ds.getHeartbeat(),
+                                Long.toString(ds.getHeartbeat()),
                                 InspectorModel.formatDouble(ds.getMinValue()),
                                 InspectorModel.formatDouble(ds.getMaxValue()),
                                 InspectorModel.formatDouble(ds.getLastValue()),
                                 InspectorModel.formatDouble(ds.getAccumValue()),
-                                "" + ds.getNanSeconds()
+                                Long.toString(ds.getNanSeconds())
                         };
                     }
                     finally {

--- a/src/main/java/org/rrd4j/inspector/EditArchiveDialog.java
+++ b/src/main/java/org/rrd4j/inspector/EditArchiveDialog.java
@@ -45,16 +45,16 @@ class EditArchiveDialog extends JDialog {
         consolFunCombo.setSelectedIndex(0);
         if (arcDef == null) {
             // NEW
-            xffField.setText("" + 0.5);
+            xffField.setText(Double.toString(0.5));
         }
         else {
             // EDIT
             consolFunCombo.setSelectedItem(arcDef.getConsolFun());
             consolFunCombo.setEnabled(false);
-            xffField.setText("" + arcDef.getXff());
-            stepsField.setText("" + arcDef.getSteps());
+            xffField.setText(Double.toString(arcDef.getXff()));
+            stepsField.setText(Integer.toString(arcDef.getSteps()));
             stepsField.setEnabled(false);
-            rowsField.setText("" + arcDef.getRows());
+            rowsField.setText(Integer.toString(arcDef.getRows()));
             // rowsField.setEnabled(false);
         }
 

--- a/src/main/java/org/rrd4j/inspector/EditDatasourceDialog.java
+++ b/src/main/java/org/rrd4j/inspector/EditDatasourceDialog.java
@@ -74,9 +74,9 @@ class EditDatasourceDialog extends JDialog {
             nameField.setEnabled(false);
             typeCombo.setSelectedItem(dsDef.getDsType());
             typeCombo.setEnabled(false);
-            heartbeatField.setText("" + dsDef.getHeartbeat());
-            minField.setText("" + dsDef.getMinValue());
-            maxField.setText("" + dsDef.getMaxValue());
+            heartbeatField.setText(Long.toString(dsDef.getHeartbeat()));
+            minField.setText(Double.toString(dsDef.getMinValue()));
+            maxField.setText(Double.toString(dsDef.getMaxValue()));
         }
 
         // layout

--- a/src/main/java/org/rrd4j/inspector/HeaderTableModel.java
+++ b/src/main/java/org/rrd4j/inspector/HeaderTableModel.java
@@ -63,11 +63,11 @@ class HeaderTableModel extends AbstractTableModel {
             try {
                 Header header = rrd.getHeader();
                 String signature = header.getSignature();
-                String step = "" + header.getStep();
+                String step = Long.toString(header.getStep());
                 String lastTimestamp = header.getLastUpdateTime() + " [" +
                         new Date(header.getLastUpdateTime() * 1000L) + "]";
-                String datasources = "" + header.getDsCount();
-                String archives = "" + header.getArcCount();
+                String datasources = Integer.toString(header.getDsCount());
+                String archives = Integer.toString(header.getArcCount());
                 String size = rrd.getRrdBackend().getLength() + " bytes";
                 values = new Object[]{
                         path, signature, step, lastTimestamp, datasources, archives, size

--- a/src/main/java/org/rrd4j/inspector/InspectorModel.java
+++ b/src/main/java/org/rrd4j/inspector/InspectorModel.java
@@ -70,6 +70,6 @@ class InspectorModel {
     }
 
     static String formatDouble(double x) {
-        return formatDouble(x, "" + Double.NaN);
+        return formatDouble(x, Double.toString(Double.NaN));
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2131 - Primitives should not be boxed just for 'String' conversion.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2131
Please let me know if you have any questions.
George Kankava