### PR TITLE
squid:S2142 - 'InterruptedException' should not be ignored

### DIFF
--- a/src/main/java/org/rrd4j/core/RrdDbPool.java
+++ b/src/main/java/org/rrd4j/core/RrdDbPool.java
@@ -159,6 +159,7 @@ public class RrdDbPool {
                     full.signalAll();
                     countLock.unlock();
                 } catch (InterruptedException e1) {
+                    Thread.currentThread().interrupt();
                 }
             }
             break;
@@ -186,6 +187,7 @@ public class RrdDbPool {
         try {
             ref = getEntry(rrdDb.getPath(), false);
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException("release interrupted for " + rrdDb, e);
         }
         if(ref == null) {
@@ -231,6 +233,7 @@ public class RrdDbPool {
         try {
             ref = getEntry(path, true);
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException("request interrupted for " + path, e);
         }
 
@@ -307,6 +310,7 @@ public class RrdDbPool {
             ref.rrdDb = new RrdDb(rrdDef);
             return ref.rrdDb;
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException("request interrupted for new rrdDef " + rrdDef.getPath(), e);
         } finally {
             if(ref != null) {
@@ -341,6 +345,7 @@ public class RrdDbPool {
             ref.rrdDb = new RrdDb(path, sourcePath);
             return ref.rrdDb;
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException("request interrupted for new rrd " + path, e);
         } finally {
             if(ref != null) {
@@ -404,6 +409,7 @@ public class RrdDbPool {
                 return ref.count;
             }
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new RuntimeException("getOpenCount interrupted", e);
         } finally {
             if(ref != null) {

--- a/src/main/java/org/rrd4j/core/RrdSafeFileBackend.java
+++ b/src/main/java/org/rrd4j/core/RrdSafeFileBackend.java
@@ -51,6 +51,7 @@ public class RrdSafeFileBackend extends RrdRandomAccessFileBackend {
                 Thread.sleep(lockRetryPeriod);
             }
             catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
                 // NOP
             }
             lock = channel.tryLock(0, Long.MAX_VALUE, false);


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S2142 - 'InterruptedException' should not be ignored.
You can find more information about the issue here:
`InterruptedExceptions` should never be ignored in the code, and simply logging the exception counts in this case as "ignoring". Instead, `InterruptedExceptions` should either be rethrown - immediately or after cleaning up the method's state - or the method should be reinterrupted. Any other course of action risks delaying thread shutdown and loses the information that the thread was interrupted - probably without finishing its task.

Noncompliant Code Example

`public void run () {`
`  try {`
`    while (true) { `
`      // do stuff`
`    }`
`  }catch (InterruptedException e) { // Noncompliant; logging is not enough`
`    LOGGER.log(Level.WARN, "Interrupted!", e);`
`  }`
`}`

Compliant Solution

`public void run () {`
`  try {`
`    while (true) { `
`      // do stuff`
`    }`
`  }catch (InterruptedException e) {`
`    LOGGER.log(Level.WARN, "Interrupted!", e);`
`    // clean up state...`
`    Thread.currentThread().interrupt();`
`  }`
`}`

Please let me know if you have any questions.
George Kankava