### PR TITLE
Fix #102: Provide a means to validate rrd databases

### DIFF
--- a/src/main/java/org/rrd4j/core/Header.java
+++ b/src/main/java/org/rrd4j/core/Header.java
@@ -212,13 +212,17 @@ public class Header implements RrdUpdater {
         return version;
     }
 
-    boolean isRrd4jHeader() throws IOException {
-        return signature.get().startsWith(SIGNATURE) || signature.get().startsWith("JR"); // backwards compatible with JRobin
+    boolean isRrd4jHeader() {
+        try {
+            return signature.get().startsWith(SIGNATURE) || signature.get().startsWith("JR"); // backwards compatible with JRobin
+        } catch (IOException ioe) {
+            return false;
+        }
     }
 
     void validateHeader() throws IOException {
         if (!isRrd4jHeader()) {
-            throw new IOException("Invalid file header. File [" + parentDb.getCanonicalPath() + "] is not a RRD4J RRD file");
+            throw new InvalidRrdException("Invalid file header. File [" + parentDb.getCanonicalPath() + "] is not a RRD4J RRD file");
         }
     }
 

--- a/src/main/java/org/rrd4j/core/InvalidRrdException.java
+++ b/src/main/java/org/rrd4j/core/InvalidRrdException.java
@@ -1,0 +1,14 @@
+package org.rrd4j.core;
+
+/**
+ * An exception indicating a corrupted RRD header.
+ */
+public class InvalidRrdException extends RrdException {
+
+   private static final long serialVersionUID = 1L;
+
+   public InvalidRrdException(String message) {
+       super(message);
+   }
+   
+}

--- a/src/main/java/org/rrd4j/core/RrdDb.java
+++ b/src/main/java/org/rrd4j/core/RrdDb.java
@@ -776,6 +776,17 @@ public class RrdDb implements RrdUpdater, Closeable {
             archive.archive(dsIndex, value, numUpdates);
         }
     }
+    
+    final void archive(Datasource datasource, double value, double lastValue, long numUpdates) throws IOException {
+       int dsIndex = getDsIndex(datasource.getName());
+       for (Archive archive : archives) {
+          if(ConsolFun.AVERAGE.equals(archive.getConsolFun())) { 
+             archive.archive(dsIndex, value, numUpdates);
+          } else {
+             archive.archive(dsIndex, lastValue, numUpdates);
+          }
+       }
+   }
 
     /**
      * Returns internal index number for the given datasource name.

--- a/src/main/java/org/rrd4j/core/RrdException.java
+++ b/src/main/java/org/rrd4j/core/RrdException.java
@@ -1,0 +1,16 @@
+package org.rrd4j.core;
+
+import java.io.IOException;
+
+/**
+ * A general purpose RRD4J exception. 
+ */
+public class RrdException extends IOException {
+
+   private static final long serialVersionUID = 1L;
+
+   public RrdException(String message) {
+      super(message);
+   }
+   
+}

--- a/src/test/java/org/rrd4j/core/RrdDbTest.java
+++ b/src/test/java/org/rrd4j/core/RrdDbTest.java
@@ -1,5 +1,6 @@
 package org.rrd4j.core;
 
+import static org.junit.Assert.*;
 import static org.rrd4j.ConsolFun.AVERAGE;
 import static org.rrd4j.ConsolFun.MAX;
 import static org.rrd4j.ConsolFun.TOTAL;
@@ -223,6 +224,30 @@ public class RrdDbTest {
         checkValues(rrd);
     }
 
+    @Test
+    public void testReadCorruptSignature() throws Exception {
+        URL url = getClass().getResource("/corrupt.rrd"); 
+        RrdBackendFactory backendFactory = RrdBackendFactory.getFactory("FILE");
+       
+        try {
+            new RrdDb(url.getFile(), backendFactory);
+            fail();
+        } catch (InvalidRrdException expected) {
+        }
+    }
+    
+    @Test
+    public void testReadEmpty() throws Exception {
+        URL url = getClass().getResource("/empty.rrd"); 
+        RrdBackendFactory backendFactory = RrdBackendFactory.getFactory("FILE");
+       
+        try {
+            new RrdDb(url.getFile(), backendFactory);
+            fail();
+        } catch (InvalidRrdException expected) {
+        }
+    }
+    
     @Test
     public void testXml1Import() throws IOException {
         URL url = getClass().getResource("/rrdtool/rrdtool1.xml"); 

--- a/src/test/resources/corrupt.rrd
+++ b/src/test/resources/corrupt.rrd
@@ -1,0 +1,1 @@
+corrupt rrd signature corrupt rrd signature corrupt rrd signature corrupt rrd signature corrupt rrd signature corrupt rrd signature  


### PR DESCRIPTION
This change introduces an InvalidRrdException (derived from
RrdException > IOException) that is used to signal a corrupted RRD
header.