### PR TITLE
change the equality test between two float

### DIFF
--- a/src/main/java/org/rrd4j/core/ArcDef.java
+++ b/src/main/java/org/rrd4j/core/ArcDef.java
@@ -127,7 +127,7 @@ public class ArcDef {
     }
 
     boolean exactlyEqual(ArcDef def) {
-        return consolFun == def.consolFun && Double.compare(xff,def.xff)==0 && steps == def.steps && rows == def.rows;
+        return consolFun == def.consolFun && Double.compare(xff,def.xff)==0  && steps == def.steps && rows == def.rows;
     }
 
 }

--- a/src/main/java/org/rrd4j/core/ArcDef.java
+++ b/src/main/java/org/rrd4j/core/ArcDef.java
@@ -127,7 +127,7 @@ public class ArcDef {
     }
 
     boolean exactlyEqual(ArcDef def) {
-        return consolFun == def.consolFun && xff == def.xff && steps == def.steps && rows == def.rows;
+        return consolFun == def.consolFun && Float.compare(xff,def.xff)==0 && steps == def.steps && rows == def.rows;
     }
 
 }

--- a/src/main/java/org/rrd4j/core/ArcDef.java
+++ b/src/main/java/org/rrd4j/core/ArcDef.java
@@ -127,7 +127,7 @@ public class ArcDef {
     }
 
     boolean exactlyEqual(ArcDef def) {
-        return consolFun == def.consolFun && Float.compare(xff,def.xff)==0 && steps == def.steps && rows == def.rows;
+        return consolFun == def.consolFun && Double.compare(xff,def.xff)==0 && steps == def.steps && rows == def.rows;
     }
 
 }


### PR DESCRIPTION
Floating point math is imprecise because of the challenges of storing such values in a binary representation. So I change the `xff == def.xff` to `Float.compare(xff,def.xff)==0`
[https://rules.sonarsource.com/java/RSPEC-1244](url)