### PR TITLE
Provide a method for closing all known RrdBackendFactory implementations

### DIFF
--- a/src/main/java/org/rrd4j/core/RrdBackendFactory.java
+++ b/src/main/java/org/rrd4j/core/RrdBackendFactory.java
@@ -97,6 +97,21 @@ public abstract class RrdBackendFactory implements Closeable {
     }
 
     /**
+     * Closes all known {@link RrdBackendFactory} implementations.
+     * 
+     * @throws IOException
+     */
+    public static void closeAll() throws IOException {
+        List<RrdBackendFactory> factories = new ArrayList<>();
+        factories.addAll(Registry.factories.values());
+        factories.addAll(activeFactories);
+        
+        for (RrdBackendFactory factory : factories) {
+            factory.close();
+        }
+    }
+
+    /**
      * The default factory type. It will also put in the active factories list.
      * 
      */


### PR DESCRIPTION
The problem is that when closing RrdDb, the backend factories are not closed and some resources of the backends stay alive, such as the RrdSyncThreadPool used in the NIO backend. By calling this new method, all backend factories are closed, too.