### PR TITLE
RrdNioBackendFactory uses a sync thread pool factory to automatically…

### DIFF
--- a/src/main/java/org/rrd4j/core/RrdBackendFactory.java
+++ b/src/main/java/org/rrd4j/core/RrdBackendFactory.java
@@ -507,10 +507,7 @@ public abstract class RrdBackendFactory implements Closeable {
      * @throws java.io.IOException Thrown in case of I/O error.
      */
     RrdBackend getBackend(RrdDb rrdDb, URI uri, boolean readOnly) throws IOException {
-        checkClosing();
-        RrdBackend backend =  open(getPath(uri), readOnly);
-        backend.done(this, new ClosingReference(rrdDb, backend, refQueue));
-        return backend;
+        return getBackend(rrdDb, getPath(uri), readOnly);
     }
 
     /**


### PR DESCRIPTION
… free resources when closing

This allows clients to use the default behavior of the RrdBackendFactory and just call close() on the NIO factory to shut down the sync thread pool. Subsequent attempts at using a NIO backend will create a new sync thread automatically.