### PR TITLE
Fix slow RrdGraph generation with big data sets

### DIFF
--- a/src/main/java/org/rrd4j/graph/RrdGraph.java
+++ b/src/main/java/org/rrd4j/graph/RrdGraph.java
@@ -679,7 +679,7 @@ public class RrdGraph implements RrdGraphConstants {
 
     private void fetchData() throws IOException {
         dproc = new DataProcessor(gdef.startTime, gdef.endTime);
-        dproc.setPixelCount(im.xsize);
+        dproc.setPixelCount(gdef.width);
         if (gdef.poolUsed) {
             dproc.setPoolUsed(gdef.poolUsed);
             dproc.setPool(gdef.getPool());


### PR DESCRIPTION
Pixel count was set to uninitialized value im.xsize and ended up being 0.