### PR TITLE
AXIS font was used instead of UNIT font

### DIFF
--- a/src/main/java/org/rrd4j/graph/RrdGraphConstants.java
+++ b/src/main/java/org/rrd4j/graph/RrdGraphConstants.java
@@ -505,7 +505,7 @@ public interface RrdGraphConstants {
 
     FontTag FONTTAG_AXIS      = FontTag.AXIS;
 
-    FontTag FONTTAG_UNIT      = FontTag.AXIS;
+    FontTag FONTTAG_UNIT      = FontTag.UNIT;
 
     FontTag FONTTAG_LEGEND    = FontTag.LEGEND;
 


### PR DESCRIPTION
Probably due to a copy-paste mistake, wrong font was sometimes used.