### PR TITLE
Avoid y-axis label corruption when using large axis font

### DIFF
--- a/src/main/java/org/rrd4j/graph/ValueAxis.java
+++ b/src/main/java/org/rrd4j/graph/ValueAxis.java
@@ -106,6 +106,10 @@ class ValueAxis extends Axis {
                 }
                 gridstep = selectedYLabel.grid * im.magfact;
                 labfact = findLabelFactor(selectedYLabel);
+                if(labfact == -1) {
+                    // as a fallback, use the largest label factor of the selected label
+                    labfact = selectedYLabel.labelFacts[3];
+                }
             }
         }
         else {


### PR DESCRIPTION
If proper label factor was not found, -1 was used, which caused serious corruption of the value axis labels. Instead, use a fallback that usually produces acceptable results.