### PR TITLE
Omit redundant fractional part on y-axis labels

### DIFF
--- a/src/main/java/org/rrd4j/graph/ValueAxis.java
+++ b/src/main/java/org/rrd4j/graph/ValueAxis.java
@@ -2,6 +2,8 @@ package org.rrd4j.graph;
 
 import java.awt.Font;
 import java.awt.Paint;
+import java.math.BigDecimal;
+import java.math.MathContext;
 
 import org.rrd4j.core.Util;
 
@@ -120,13 +122,14 @@ class ValueAxis extends Axis {
         int sgrid = (int) (im.minval / gridstep - 1);
         int egrid = (int) (im.maxval / gridstep + 1);
         double scaledstep = gridstep / im.magfact;
+        boolean fractional = isFractional(scaledstep, labfact);
         for (int i = sgrid; i <= egrid; i++) {
             int y = mapper.ytr(gridstep * i);
             if (y >= im.yorigin - im.ysize && y <= im.yorigin) {
                 if (i % labfact == 0) {
                     String graph_label;
                     if (i == 0 || im.symbol == ' ') {
-                        if (scaledstep < 1) {
+                        if (fractional) {
                             if (i != 0 && gdef.altYGrid) {
                                 graph_label = Util.sprintf(gdef.locale, labfmt, scaledstep * i);
                             }
@@ -139,7 +142,7 @@ class ValueAxis extends Axis {
                         }
                     }
                     else {
-                        if (scaledstep < 1) {
+                        if (fractional) {
                             graph_label = Util.sprintf(gdef.locale, "%4.1f %c", scaledstep * i, im.symbol);
                         }
                         else {
@@ -239,6 +242,18 @@ class ValueAxis extends Axis {
     private double getScaledRange() {
         double range = im.maxval - im.minval;
         return range / im.magfact;
+    }
+
+    /**
+     * Returns true if some or all labels have fractional part (other than zero).
+     */
+    private static boolean isFractional(double scaledstep, int labfact) {
+        if (scaledstep >= 1) {
+            return false;
+        }
+        BigDecimal bd = BigDecimal.valueOf(scaledstep)
+                .multiply(BigDecimal.valueOf(labfact), MathContext.DECIMAL32);
+        return !(bd.signum() == 0 || bd.scale() <= 0 || bd.stripTrailingZeros().scale() <= 0);
     }
 
     static class YLabel {


### PR DESCRIPTION
If every label on y-axis ends with .0 (e.g. 5.0, 10.0, 15.0, 20.0, ...) then omit the zero fraction (e.g. 5, 10, 15, 20, ...).