### PR TITLE
Use correct fonts when calculating limits

### DIFF
--- a/src/main/java/org/rrd4j/graph/RrdGraph.java
+++ b/src/main/java/org/rrd4j/graph/RrdGraph.java
@@ -449,7 +449,7 @@ public class RrdGraph implements RrdGraphConstants {
             im.xorigin = 0;
         }
         else {
-            im.xorigin = (int) (PADDING_LEFT + im.unitslength * getFontCharWidth(FontTag.UNIT));
+            im.xorigin = (int) (PADDING_LEFT + im.unitslength * getFontCharWidth(FONTTAG_AXIS));
         }
 
         if (!gdef.onlyGraph && gdef.verticalLabel != null) {
@@ -473,7 +473,7 @@ public class RrdGraph implements RrdGraphConstants {
         }
         else {
             im.xgif = PADDING_RIGHT + im.xsize + im.xorigin;
-            im.ygif = im.yorigin + (int) (PADDING_PLOT * getFontHeight(FONTTAG_DEFAULT));
+            im.ygif = im.yorigin + (int) (PADDING_PLOT * getFontHeight(FONTTAG_AXIS));
         }
     }
 


### PR DESCRIPTION
Wrong fonts were used for x-axis and y-axis labels when calculating image limits.