### PR TITLE
Fix order dependent tests in FontTest

### DIFF
--- a/src/test/java/org/rrd4j/graph/FontTest.java
+++ b/src/test/java/org/rrd4j/graph/FontTest.java
@@ -24,7 +24,9 @@ public class FontTest {
         System.clearProperty(PROPERTYFONTSPROPERTIES);
         System.clearProperty(PROPERTYFONTSURL);
         System.clearProperty(PROPERTYFONTPLAIN);
+        System.clearProperty(PROPERTYFONTPLAINURL);
         System.clearProperty(PROPERTYFONTBOLD);
+        System.clearProperty(PROPERTYFONTBOLDURL);
     }
 
     private Font loadFont(String path) throws FontFormatException, IOException {


### PR DESCRIPTION
#### Issue
- In `org.rrd4j.graph.FontTest`, the unit test `testExplicitURL()` can trigger `java.lang.AssertionError` when being run before the unit test `testClean()` in the same class because it pollutes state shared among tests.
- Since Junit 4 doesn't guarantee the [order of test executions](https://junit.org/junit4/javadoc/4.12/org/junit/FixMethodOrder.html), this could trigger the `testExplicitURL()` before `testClean()`, thereby resulting in test failure.
- It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

#### Reason
- The reason for this dependency is that the test `FontTest.testExplicitURL()` pollutes the state `System.setProperty(PROPERTYFONTBOLDURL)`, `System.setProperty(PROPERTYFONTPLAINURL)` at https://github.com/rrd4j/rrd4j/blob/659f4a10e0b0471cce1f84766bb260feb2dd0800/src/test/java/org/rrd4j/graph/FontTest.java#L78-L79
- However, this polluted state is not being cleaned before or after the unit test is run https://github.com/rrd4j/rrd4j/blob/659f4a10e0b0471cce1f84766bb260feb2dd0800/src/test/java/org/rrd4j/graph/FontTest.java#L23-L28
- When `testClean()` is executed with this polluted state, the value of `plain` loaded is based on the polluted state, thus resulting in the assertion failure at https://github.com/rrd4j/rrd4j/blob/659f4a10e0b0471cce1f84766bb260feb2dd0800/src/test/java/org/rrd4j/graph/FontTest.java#L59-L61
```
java.lang.AssertionError: 
Expected :java.awt.Font[family=DejaVu Sans Mono,name=DejaVu Sans Mono,style=plain,size=10]
Actual   :java.awt.Font[family=Cousine,name=Cousine Regular,style=plain,size=10]
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:120)
	at org.junit.Assert.assertEquals(Assert.java:146)
	at org.rrd4j.graph.FontTest.test02_testClean(FontTest.java:46)
```

#### Proposed fix

- Clearing the polluted states after the unit tests are run will solve this issue
- I cleared the states in the existing `clean()` method
- I am happy to discuss more about the issue