### PR TITLE
Prevent excess `RrdBackend.close()` invocation

### DIFF
--- a/src/main/java/org/rrd4j/core/RrdBackend.java
+++ b/src/main/java/org/rrd4j/core/RrdBackend.java
@@ -165,12 +165,10 @@ public abstract class RrdBackend {
      * @throws java.io.IOException Thrown in case of I/O error
      */
     protected void rrdClose() throws IOException {
-        try {
+        if (ref == null) {
             close();
-        } finally {
-            if (ref != null) {
-                ref.clear();
-            }
+        } else {
+            ref.clear();   // will call `this.close()` because `ref` is of `RrdBackendFactory.ClosingReference` type 
         }
     }
 

--- a/src/main/java/org/rrd4j/core/RrdBackend.java
+++ b/src/main/java/org/rrd4j/core/RrdBackend.java
@@ -165,10 +165,12 @@ public abstract class RrdBackend {
      * @throws java.io.IOException Thrown in case of I/O error
      */
     protected void rrdClose() throws IOException {
-        if (ref == null) {
+        try {
             close();
-        } else {
-            ref.clear();   // will call `this.close()` because `ref` is of `RrdBackendFactory.ClosingReference` type 
+        } finally {
+            if (ref != null) {
+                ref.clear();
+            }
         }
     }
 

--- a/src/main/java/org/rrd4j/core/RrdBackendFactory.java
+++ b/src/main/java/org/rrd4j/core/RrdBackendFactory.java
@@ -316,10 +316,7 @@ public abstract class RrdBackendFactory implements Closeable {
         }
         @Override
         public void clear() {
-            try {
-                backend.close();
-            } catch (IOException e) {
-            }
+            // backend doesn't need to be closed here as it already happens in RrdBackend.rrdClose()
             backend = null;
             super.clear();
         }

--- a/src/test/java/org/rrd4j/core/RrdBackendTest.java
+++ b/src/test/java/org/rrd4j/core/RrdBackendTest.java
@@ -1,0 +1,64 @@
+package org.rrd4j.core;
+
+import static org.easymock.EasyMock.partialMockBuilder;
+import static org.easymock.EasyMock.replay;
+import static org.easymock.EasyMock.verify;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.rrd4j.ConsolFun;
+import org.rrd4j.DsType;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class RrdBackendTest {
+    
+    @Test
+    public void testBackendClose() throws IOException {
+        // given
+        String fileName = "variabletest.rrd";
+        
+        RrdBackend rrdBackendMock = partialMockBuilder(RrdMemoryBackend.class)
+                .withConstructor(fileName, new AtomicReference<ByteBuffer>())
+                .addMockedMethod("close")
+                .createMock();
+        RrdBackendFactory backendFactory = new RrdMemoryBackendFactory() {
+            @Override
+            protected RrdBackend open(String id, boolean readOnly) {
+                return rrdBackendMock;
+            }
+            @Override
+            public String getName() {
+                return "memory";        // to prevent NPE upon factory construction
+            }
+        };
+        RrdDef def = createRrdDef(backendFactory, fileName);
+
+        rrdBackendMock.close();                  // record the interaction we want to verify 
+        
+        replay(rrdBackendMock);         // switch EasyMock from recording to actual execution
+
+        // when
+        try (RrdDb db = RrdDb.getBuilder()
+                .setRrdDef(def)
+                .setBackendFactory(backendFactory)
+                .build()) {
+            // a simple assertion just not to leave try block empty
+            Assert.assertEquals("Invalid step", 300L, db.getHeader().getStep());
+        }       // this line closes the database
+        
+        // then
+        verify(rrdBackendMock);     // checks that `close()` method (1) was called and (2) called exactly once
+    }
+
+    private static RrdDef createRrdDef(RrdBackendFactory backendFactory, String fileName) {
+        long start = Util.getTimestamp(2023, 12, 6);
+        RrdDef def = new RrdDef(backendFactory.getUri(fileName), start, 300);
+        def.addArchive(ConsolFun.AVERAGE, 0.5, 1, 215);
+        def.addDatasource("bar", DsType.GAUGE, 3000, Double.NaN, Double.NaN);
+        return def;
+    }
+
+}


### PR DESCRIPTION
### Problem

Currently, when closing an `RrrDb` instance after use, its backend’s `close()` method can be invoked twice. For backends based on an external storage (like built-in Mongo, Berkley or custom Cassandra, etc) this behavior causes one more (excess) update request with each completed RRD DB interaction, which in turn decreases the overall performance.

The excess invocation originates from `RrdBackend#rrdClose` method:

```java 
        try {
            close();
        } finally {
            if (ref != null) {
                ref.clear();
            }
        }
```

The **first** invocation is the direct method call in `try` body. The **second** one happens in `finally` block due to the fact that `ref` is always a `RrdBackendFactory.ClosingReference` instance whose `clear` method is overridden to call `backend.close()` method as well.

### Solution

The `RrdBackend#rrdClose` method has been re-written to take `ref` presence into account firstly and to call `close` method only if there is no `ref`:

```java
        if (ref == null) {
            close();
        } else {
            ref.clear();   // will call `this.close()` because `ref` is of `RrdBackendFactory.ClosingReference` type 
        }
```

In most cases, the backend closing should happen via reference clearing.

### Verification

The new unit test `RrdBackendTest#testBackendClose` creates a sample `RrdDb` with `RrdMemoryBackend` whose `close` invocations are analyzed by means of EasyMock library. The database is created and closed within `try-with-resources` block. When run without the fix, the test should fail with:

``` 
[ERROR] org.rrd4j.core.RrdBackendTest.testBackendClose -- Time elapsed: 0.019 s <<< FAILURE!
java.lang.AssertionError: 
  Unexpected method call RrdMemoryBackend.close():
    RrdMemoryBackend.close(): expected: 1, actual: 2
```

, while with the fix in place the test should pass successfully. 