### PR TITLE
Make RRD DB closing idempotent when used with a pool

### DIFF
--- a/src/main/java/org/rrd4j/core/RrdDbPool.java
+++ b/src/main/java/org/rrd4j/core/RrdDbPool.java
@@ -300,6 +300,9 @@ public class RrdDbPool {
         RrdEntry ref;
         try {
             ref = getEntry(dburi, false);
+        } catch (IllegalStateException e) {
+            // This means that corresponding database has been already closed before, so returning immediately.
+            return;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IllegalStateException("Release interrupted for " + rrdDb.getPath(), e);

--- a/src/test/java/org/rrd4j/core/RrdDbTest.java
+++ b/src/test/java/org/rrd4j/core/RrdDbTest.java
@@ -448,4 +448,21 @@ public class RrdDbTest {
         }
     }
 
+    @Test
+    public void testClosingIdempotency() throws IOException, URISyntaxException {
+        // given
+        RrdDbPool pool = new RrdDbPool();
+        URL url = getClass().getResource("/demo2.rrd");
+        RrdDb rrd = RrdDb.getBuilder()
+                .setPath(url.toURI())
+                .setPool(pool)
+                .build();
+        // when
+        rrd.close();            // first invocation should actually close the database
+        rrd.close();            // second (and further) invocation(s) should do nothing
+        
+        // then
+        // The test just completes normally provided that no exceptions happened before.
+    }
+
 }


### PR DESCRIPTION
### Problem

Currently, when pooling is in use, the closing of `RrdDb` instance is not idempotent: the first call to `close` actually closes the DB, while the subsequent ones produce:

```
java.lang.IllegalStateException: Unknown URI in pool: ...

	at org.rrd4j.core.RrdDbPool.lambda$getEntry$2(RrdDbPool.java:192)
	at java.base/java.util.concurrent.ConcurrentHashMap.compute(ConcurrentHashMap.java:1916)
	at org.rrd4j.core.RrdDbPool.getEntry(RrdDbPool.java:174)
	at org.rrd4j.core.RrdDbPool.release(RrdDbPool.java:302)
	at org.rrd4j.core.RrdDb.close(RrdDb.java:830)
```

This makes it difficult to implement use cases where RRD database is enclosed in `try-with-resources` block, within which some other logic may close the database e.g. due to an exception.

The problem originates from `RrdDbPool#getEntry` method which throws the `IllegalStateException` when called with `cancreate=false` and no entry found in the `pool` map.

**Note** that when pooling is not used, the `RrdDb#close` delegates to its neighbor `RrdDb#internalClose` method which checks the `closed` flag thus behaving consistently with many other `java.io.Closeable#close` implementations (i.e. behaving idempotent).

### Solution

The `RrdDbPool#release` is augmented with `IllegalStateException` suppressing because it can be thrown only in case of an entry absence in the pool. This does not affect other usages of `getEntry` method where `cancreate` argument may also be `false`.

### Verification

The new `RrdDbTest#testClosingIdempotency` test creates a simple RRD database and tries to close it twice. When run without the fix, it fails with:

```
java.lang.IllegalStateException: Unknown URI in pool: file:///home/vladimir/work/source/unsorted/rrd4j/target/test-classes/demo2.rrd

	at org.rrd4j.core.RrdDbPool.lambda$getEntry$2(RrdDbPool.java:192)
	at java.base/java.util.concurrent.ConcurrentHashMap.compute(ConcurrentHashMap.java:1916)
	at org.rrd4j.core.RrdDbPool.getEntry(RrdDbPool.java:174)
	at org.rrd4j.core.RrdDbPool.release(RrdDbPool.java:302)
	at org.rrd4j.core.RrdDb.close(RrdDb.java:830)
	at org.rrd4j.core.RrdDbTest.testClosingIdempotency(RrdDbTest.java:462)
```

, while finishes successfully with the fix in place.