### PR TITLE
Add current file name to window title of RRD File Inspector

### DIFF
--- a/src/main/java/org/rrd4j/inspector/RrdInspector.java
+++ b/src/main/java/org/rrd4j/inspector/RrdInspector.java
@@ -334,6 +334,7 @@ public class RrdInspector extends JFrame {
     private void loadFile(File file) {
         inspectorModel.setFile(file);
         tabbedPane.setSelectedIndex(0);
+        setTitle(String.format("%s - %s", file.getName(), TITLE));
     }
 
 


### PR DESCRIPTION
This makes it easier to visually distinguish the Inspector windows when working with multiple RRD files at the same time (e.g. for comparison).

![image](https://github.com/rrd4j/rrd4j/assets/12630412/b9fd2371-6aef-4b6a-8094-460b6959197c)
