### PR TITLE
Upgrade to mongodb-java-sync 4.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
         </dependency>
         <dependency>
             <groupId>org.mongodb</groupId>
-            <artifactId>mongo-java-driver</artifactId>
-            <version>3.12.14</version>
+            <artifactId>mongodb-driver-legacy</artifactId>
+            <version>4.11.2</version>
             <optional>true</optional>
         </dependency>
         <!-- Test dependencies. -->

--- a/src/test/java/org/rrd4j/core/RrdDbMongoDbTest.java
+++ b/src/test/java/org/rrd4j/core/RrdDbMongoDbTest.java
@@ -2,7 +2,10 @@ package org.rrd4j.core;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 
+import com.mongodb.MongoClientSettings;
+import com.mongodb.client.MongoClients;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -11,8 +14,7 @@ import org.rrd4j.ConsolFun;
 import org.rrd4j.DsType;
 
 import com.mongodb.DBObject;
-import com.mongodb.MongoClient;
-import com.mongodb.MongoClientOptions;
+import com.mongodb.client.MongoClient;
 import com.mongodb.ServerAddress;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
@@ -33,11 +35,14 @@ public class RrdDbMongoDbTest {
 
     @Test
     public void testLifeCycle() throws IOException {
-        try (MongoClient mongoClient = new MongoClient(Arrays.asList(new ServerAddress("localhost")),
-                new MongoClientOptions.Builder()
-                .serverSelectionTimeout(2000)
-                .minConnectionsPerHost(0)
-                .build())) {
+
+        MongoClientSettings settings = MongoClientSettings.builder()
+                .applyToClusterSettings( builder -> builder.hosts( Arrays.asList( new ServerAddress( "localhost" ) ) ) )
+                .applyToClusterSettings( builder -> builder.serverSelectionTimeout(2000, TimeUnit.MILLISECONDS))
+                .applyToConnectionPoolSettings( builder -> builder.minSize(0) )
+                .build();
+
+        try (MongoClient mongoClient = MongoClients.create(settings)) {
             MongoDatabase mongodb = mongoClient.getDatabase("mydb");
             MongoCollection<DBObject> collection = mongodb.getCollection("test", DBObject.class);
             RrdBackendFactory factory = new RrdMongoDBBackendFactory(mongoClient, collection, false);


### PR DESCRIPTION
Per discussion in #167, we've been working toward upgrading our application to the newer Mongodb drivers.   Latest is 5.1, but we use another library that has an incompatibility with 5.x so I stopped at 4.11 - would love to see this merged and a rrd4j release made.