### PR TITLE
Minor rendering improvements

### DIFF
--- a/src/main/java/org/rrd4j/core/RrdBackendFactory.java
+++ b/src/main/java/org/rrd4j/core/RrdBackendFactory.java
@@ -220,7 +220,7 @@ public abstract class RrdBackendFactory implements Closeable {
     
     /**
      * Return the current active factories as a stream.
-     * @return
+     * @return the Stream
      * @since 3.7
      */
     public static synchronized Stream<RrdBackendFactory> getActiveFactories() {

--- a/src/main/java/org/rrd4j/core/RrdDb.java
+++ b/src/main/java/org/rrd4j/core/RrdDb.java
@@ -212,7 +212,7 @@ public class RrdDb implements RrdUpdater<RrdDb>, Closeable {
         /**
          * Internal method used to memorize the pool, without generating a loop
          * @param pool
-         * @return
+         * @return the Builder
          */
         Builder setPoolInternal(RrdDbPool pool) {
             this.pool = pool;

--- a/src/main/java/org/rrd4j/core/XmlWriter.java
+++ b/src/main/java/org/rrd4j/core/XmlWriter.java
@@ -77,7 +77,7 @@ public class XmlWriter implements AutoCloseable {
     /**
      * Return a new {@link XmlWriter} that will format time stamp as ISO 8601 with this explicit time zone {@link ZoneId}
      * @param zid
-     * @return
+     * @return the XmlWriter
      */
     public XmlWriter withTimeZone(ZoneId zid) {
         if (indent.length() != 0 || !openTags.isEmpty()) {
@@ -90,7 +90,7 @@ public class XmlWriter implements AutoCloseable {
     /**
      * Return a new {@link XmlWriter} that will format time stamp using this {@link ZoneId}
      * @param doubleFormatter
-     * @return
+     * @return the XmlWriter
      */
     public XmlWriter withDoubleFormatter(DoubleFormater doubleFormatter) {
         if (indent.length() != 0 || !openTags.isEmpty()) {
@@ -262,7 +262,7 @@ public class XmlWriter implements AutoCloseable {
      * Format a timestamp using the configured {@link DateTimeFormatter}
      *
      * @param timestamp
-     * @return
+     * @return the formatted timestamp
      */
     public String formatTimestamp(long timestamp) {
          return timeFormatter.format(Instant.ofEpochSecond(timestamp));

--- a/src/main/java/org/rrd4j/data/Source.java
+++ b/src/main/java/org/rrd4j/data/Source.java
@@ -33,7 +33,7 @@ abstract class Source {
     /**
      * @param tStart
      * @param tEnd
-     * @return
+     * @return the Aggregates
      * @deprecated This method is deprecated. Uses instance of {@link org.rrd4j.data.Variable}, used with {@link org.rrd4j.data.DataProcessor#addDatasource(String, String, Variable)}
      */
     @Deprecated
@@ -46,7 +46,7 @@ abstract class Source {
      * @param tStart
      * @param tEnd
      * @param percentile
-     * @return
+     * @return the percentile
      * @deprecated This method is deprecated. Uses instance of {@link org.rrd4j.data.Variable.PERCENTILE}, used with {@link org.rrd4j.data.DataProcessor#addDatasource(String, String, Variable)}
      */
     @Deprecated

--- a/src/main/java/org/rrd4j/graph/TimeAxis.java
+++ b/src/main/java/org/rrd4j/graph/TimeAxis.java
@@ -1,5 +1,6 @@
 package org.rrd4j.graph;
 
+import java.awt.BasicStroke;
 import java.awt.Font;
 import java.awt.Paint;
 import java.util.Calendar;
@@ -14,8 +15,8 @@ class TimeAxis extends Axis {
             new TimeAxisSetting(30, MINUTE, 10, HOUR, 1, HOUR, 1, 0, HH_MM),
             new TimeAxisSetting(60, MINUTE, 30, HOUR, 2, HOUR, 2, 0, HH_MM),
             new TimeAxisSetting(180, HOUR, 1, HOUR, 6, HOUR, 6, 0, HH_MM),
-            new TimeAxisSetting(600, HOUR, 6, DAY, 1, DAY, 1, 24 * 3600, "EEE"),
-            new TimeAxisSetting(1800, HOUR, 12, DAY, 1, DAY, 2, 24 * 3600, "EEE"),
+            new TimeAxisSetting(600, HOUR, 6, DAY, 1, DAY, 1, 24 * 3600, "EEE dd"),
+            new TimeAxisSetting(1800, HOUR, 12, DAY, 1, DAY, 2, 24 * 3600, "EEE dd"),
             new TimeAxisSetting(3600, DAY, 1, WEEK, 1, WEEK, 1, 7 * 24 * 3600, "'Week 'w"),
             new TimeAxisSetting(3 * 3600L, WEEK, 1, MONTH, 1, WEEK, 2, 7 * 24 * 3600, "'Week 'w"),
             new TimeAxisSetting(6 * 3600L, MONTH, 1, MONTH, 1, MONTH, 1, 30 * 24 * 3600, "MMM"),
@@ -75,6 +76,8 @@ class TimeAxis extends Axis {
 
     private void drawMinor() {
         if (!gdef.noMinorGrid) {
+            // skip ticks if zero width
+            boolean ticks = ((BasicStroke)gdef.tickStroke).getLineWidth() > 0;
             adjustStartingTime(tickSetting.minorUnit, tickSetting.minorUnitCount);
             Paint color = gdef.getColor(ElementsNames.grid);
             int y0 = im.yorigin, y1 = y0 - im.ysize;
@@ -82,7 +85,8 @@ class TimeAxis extends Axis {
                 if (status == 0) {
                     long time = calendar.getTime().getTime() / 1000L;
                     int x = mapper.xtr(time);
-                    worker.drawLine(x, y0 - 1, x, y0 + 1, color, gdef.tickStroke);
+                    if (ticks)
+                        worker.drawLine(x, y0 - 1, x, y0 + 1, color, gdef.tickStroke);
                     worker.drawLine(x, y0, x, y1, color, gdef.gridStroke);
                 }
                 findNextTime(tickSetting.minorUnit, tickSetting.minorUnitCount);
@@ -91,6 +95,8 @@ class TimeAxis extends Axis {
     }
 
     private void drawMajor() {
+        // skip ticks if zero width
+        boolean ticks = ((BasicStroke)gdef.tickStroke).getLineWidth() > 0;
         adjustStartingTime(tickSetting.majorUnit, tickSetting.majorUnitCount);
         Paint color = gdef.getColor(ElementsNames.mgrid);
         int y0 = im.yorigin, y1 = y0 - im.ysize;
@@ -98,7 +104,8 @@ class TimeAxis extends Axis {
             if (status == 0) {
                 long time = calendar.getTime().getTime() / 1000L;
                 int x = mapper.xtr(time);
-                worker.drawLine(x, y0 - 2, x, y0 + 2, color, gdef.tickStroke);
+                if (ticks)
+                    worker.drawLine(x, y0 - 2, x, y0 + 2, color, gdef.tickStroke);
                 worker.drawLine(x, y0, x, y1, color, gdef.gridStroke);
             }
             findNextTime(tickSetting.majorUnit, tickSetting.majorUnitCount);

--- a/src/main/java/org/rrd4j/graph/ValueAxis.java
+++ b/src/main/java/org/rrd4j/graph/ValueAxis.java
@@ -1,5 +1,6 @@
 package org.rrd4j.graph;
 
+import java.awt.BasicStroke;
 import java.awt.Font;
 import java.awt.Paint;
 import java.math.BigDecimal;
@@ -132,6 +133,8 @@ class ValueAxis extends Axis {
         int egrid = (int) (im.maxval / gridstep + 1);
         double scaledstep = gridstep / im.magfact;
         boolean fractional = isFractional(scaledstep, labfact);
+        // skip ticks if zero width
+        boolean ticks = ((BasicStroke)gdef.tickStroke).getLineWidth() > 0;
         for (int i = sgrid; i <= egrid; i++) {
             int y = mapper.ytr(gridstep * i);
             if (y >= im.yorigin - im.ysize && y <= im.yorigin) {
@@ -151,7 +154,10 @@ class ValueAxis extends Axis {
                         }
                     }
                     else {
-                        if (fractional) {
+                        if (im.symbol == 'm') {
+                            // show 0.xxx instead of xxx m
+                            graph_label = Util.sprintf(gdef.locale, "%.3f", scaledstep * i / 1000);
+                        } else if (fractional) {
                             graph_label = Util.sprintf(gdef.locale, "%4.1f %c", scaledstep * i, im.symbol);
                         }
                         else {
@@ -160,13 +166,17 @@ class ValueAxis extends Axis {
                     }
                     int length = (int) (worker.getStringWidth(graph_label, font));
                     worker.drawString(graph_label, x0 - length - PADDING_VLABEL, y + labelOffset, font, fontColor);
-                    worker.drawLine(x0 - 2, y, x0 + 2, y, mGridColor, gdef.tickStroke);
-                    worker.drawLine(x1 - 2, y, x1 + 2, y, mGridColor, gdef.tickStroke);
+                    if (ticks) {
+                        worker.drawLine(x0 - 2, y, x0 + 2, y, mGridColor, gdef.tickStroke);
+                        worker.drawLine(x1 - 2, y, x1 + 2, y, mGridColor, gdef.tickStroke);
+                    }
                     worker.drawLine(x0, y, x1, y, mGridColor, gdef.gridStroke);
                 }
                 else if (!(gdef.noMinorGrid)) {
-                    worker.drawLine(x0 - 1, y, x0 + 1, y, gridColor, gdef.tickStroke);
-                    worker.drawLine(x1 - 1, y, x1 + 1, y, gridColor, gdef.tickStroke);
+                    if (ticks) {
+                        worker.drawLine(x0 - 1, y, x0 + 1, y, gridColor, gdef.tickStroke);
+                        worker.drawLine(x1 - 1, y, x1 + 1, y, gridColor, gdef.tickStroke);
+                    }
                     worker.drawLine(x0, y, x1, y, gridColor, gdef.gridStroke);
                 }
             }

--- a/src/main/java/org/rrd4j/graph/ValueScaler.java
+++ b/src/main/java/org/rrd4j/graph/ValueScaler.java
@@ -3,7 +3,7 @@ package org.rrd4j.graph;
 class ValueScaler {
     static final String UNIT_UNKNOWN = "?";
     static final String[] UNIT_SYMBOLS = {
-            "a", "f", "p", "n", "u", "m", " ", "k", "M", "G", "T", "P", "E"
+            "a", "f", "p", "n", "µ", "m", " ", "k", "M", "G", "T", "P", "E"
     };
     static final int SYMB_CENTER = 6;
 
@@ -16,6 +16,9 @@ class ValueScaler {
     }
 
     Scaled scale(double value, boolean mustRescale) {
+        // avoid NaN in legend
+        if (Double.isNaN(value))
+            value = 0.0;
         Scaled scaled;
         if (mustRescale) {
             scaled = rescale(value);


### PR DESCRIPTION
This is a collection of minor changes we use in I2P. Some of it is a matter of taste or may be different than what jrobin did. Other changes omit output when the alpha or stroke is 0, which is useful for SVG output but is more efficient regardless. Please review and cherrypick what you like and skip what you don't.

- Change u to micron in legend to match value axis
- Combine drawRules() and drawSpans() to only iterate through plotElements once
- Only clip and reset in drawRulesAndSpans() if we output something
- Move title up a little for better padding below
- Position long titles to clip only on right side
- Don't draw arrowheads if disabled by color alpha of 0
- Don't draw ticks if disabled by stroke width of 0
- Don't draw three legend color boxes on top of each other unless all have some transparency
- Replace NaN with 0 in legend values
- Output milli values as 0.xxx rather than xxx m
- Add day number to time axis day names
- Javadoc warning fixes